### PR TITLE
bugfix

### DIFF
--- a/datastore_api/adapter/db/__init__.py
+++ b/datastore_api/adapter/db/__init__.py
@@ -16,17 +16,19 @@ class DatabaseClient(Protocol):
     def get_job(self, job_id: int | str) -> Job: ...
     def get_jobs(
         self,
+        *,
         datastore_id: int | None,
         status: JobStatus | None,
         operations: list[Operation] | None,
         ignore_completed: bool = False,
     ) -> list[Job]: ...
     def get_jobs_for_target(
-        self, name: str, datastore_id: int
+        self, *, name: str, datastore_id: int
     ) -> list[Job]: ...
     def new_job(self, new_job: Job) -> Job: ...
     def update_job(
         self,
+        *,
         job_id: str,
         status: JobStatus | None,
         description: str | None,

--- a/datastore_api/api/importable_datasets.py
+++ b/datastore_api/api/importable_datasets.py
@@ -39,7 +39,10 @@ def get_importable_datasets(
     in_progress_targets = [
         job.parameters.target
         for job in db_client.get_jobs(
-            datastore_id, status=None, operations=None, ignore_completed=True
+            datastore_id=datastore_id,
+            status=None,
+            operations=None,
+            ignore_completed=True,
         )
     ]
     datastore_input_dir = Path(

--- a/datastore_api/api/targets.py
+++ b/datastore_api/api/targets.py
@@ -24,4 +24,6 @@ def get_target_jobs(
     database_client: db.DatabaseClient = Depends(db.get_database_client),
     datastore_id: int = Depends(get_datastore_id),
 ) -> list[Job]:
-    return database_client.get_jobs_for_target(name, datastore_id)
+    return database_client.get_jobs_for_target(
+        name=name, datastore_id=datastore_id
+    )

--- a/tests/integration/adapter/test_sqlite.py
+++ b/tests/integration/adapter/test_sqlite.py
@@ -288,7 +288,7 @@ def test_get_jobs():
 
 def test_get_jobs_for_target():
     jobs = sqlite_client.get_jobs_for_target(
-        "MY_DATASET", datastore_id=DATASTORE_ID
+        name="MY_DATASET", datastore_id=DATASTORE_ID
     )
     assert len(jobs) == 1
 
@@ -306,7 +306,7 @@ def test_new_job():
     )
     assert job
     jobs = sqlite_client.get_jobs_for_target(
-        "NEW_DATASET", datastore_id=DATASTORE_ID
+        name="NEW_DATASET", datastore_id=DATASTORE_ID
     )
     assert len(jobs) == 1
     with pytest.raises(JobExistsException):

--- a/tests/unit/api/test_targets.py
+++ b/tests/unit/api/test_targets.py
@@ -90,7 +90,9 @@ def test_get_targets(client, mock_db_client):
 def test_get_target(client, mock_db_client):
     response = client.get("/targets/MY_DATASET/jobs")
     mock_db_client.get_jobs_for_target.assert_called_once()
-    mock_db_client.get_jobs_for_target.assert_called_with("MY_DATASET", 1)
+    mock_db_client.get_jobs_for_target.assert_called_with(
+        name="MY_DATASET", datastore_id=1
+    )
     assert response.status_code == 200
     assert response.json() == [
         job.model_dump(exclude_none=True, by_alias=True) for job in JOB_LIST


### PR DESCRIPTION
Missing use of keyword before arg (datasdtore_id) in a get_jobs() call. Resulted in a bug. Also updated get_jobs_for_targets() with using keyword-args in the same way.