### PR TITLE
Added observability endpoints to rnd path to maintain compatibility

### DIFF
--- a/datastore_api/api/__init__.py
+++ b/datastore_api/api/__init__.py
@@ -47,6 +47,9 @@ def _include_routers(app: FastAPI) -> None:
     )
     app.include_router(observability.router, prefix="/health")
     app.include_router(
+        observability.router, prefix="/datastores/{datastore_rdn}/health"
+    )
+    app.include_router(
         maintenance_statuses.router, prefix="/maintenance-statuses"
     )
     app.include_router(jobs.router, prefix="/jobs")


### PR DESCRIPTION
Sikt services are using these endpoints so to make the migration smoother we added these under /datastores/rdn/health


https://github.com/orgs/statisticsnorway/projects/36/views/3?pane=issue&itemId=140696694&issue=statisticsnorway%7Cmicrodata-system%7C165