### PR TITLE
Use env variables for secrets in workflow scripts

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -96,14 +96,14 @@ jobs:
         uses: actions/github-script@v7
         env:
           INTEGRATION_TEST_REPO: ${{ secrets.INTEGRATION_TEST_REPO }}
-          INTEGRATION_TEST_WORKFLOW: ${{ secrets.INTEGRATION_TEST_WORKFLOW }}
+          INTEGRATION_TEST_WORKFLOW: "${{ secrets.INTEGRATION_TEST_WORKFLOW }}.yaml"
         with:
           github-token: ${{ secrets.INTEGRATION_TEST_PAT }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'statisticsnorway',
               repo: process.env.INTEGRATION_TEST_REPO,
-              workflow_id: process.env.INTEGRATION_TEST_WORKFLOW + '.yaml',
+              workflow_id: process.env.INTEGRATION_TEST_WORKFLOW,
               ref: 'main'
             })
 
@@ -140,14 +140,14 @@ jobs:
         uses: actions/github-script@v7
         env:
           DEPLOY_REPO: ${{ secrets.DEPLOY_REPO }}
-          DEPLOY_WORKFLOW: ${{ secrets.DEPLOY_WORKFLOW }}
+          DEPLOY_WORKFLOW: "${{ secrets.DEPLOY_WORKFLOW }}.yaml"
         with:
           github-token: ${{ secrets.DEPLOY_PAT }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'statisticsnorway',
               repo: process.env.DEPLOY_REPO,
-              workflow_id: process.env.DEPLOY_WORKFLOW + '.yaml',
+              workflow_id: process.env.DEPLOY_WORKFLOW,
               ref: 'master',
               inputs: {
                 environment: "PROD",


### PR DESCRIPTION
## Env for secrets in gha-workflows
Ref [issue](https://github.com/orgs/statisticsnorway/projects/36/views/3?pane=issue&itemId=138786670&issue=statisticsnorway%7Cmicrodata-system%7C140) on using env for secrets in GHA workflows:

I have

- reviewed all workflows in this repository
- ensured that all secrets are injected through env: or with: instead of being referenced inline inside run: or script: blocks