### PR TITLE
Use rdn directly as directory-name

### DIFF
--- a/datastore_api/domain/datastores/__init__.py
+++ b/datastore_api/domain/datastores/__init__.py
@@ -27,8 +27,7 @@ logger = logging.getLogger()
 
 def get_datastore_dir_from_rdn(rdn: str) -> str:
     root_dir = Path(DATASTORES_ROOT_DIR)
-    dir_name = rdn.replace(".", "-").lower()
-    datastore_dir = root_dir / dir_name
+    datastore_dir = root_dir / rdn
     if not datastore_dir.resolve().is_relative_to(root_dir.resolve()):
         raise ValueError(
             "Resolved datastore directory is outside allowed base directory"

--- a/tests/unit/api/datastores/test_models.py
+++ b/tests/unit/api/datastores/test_models.py
@@ -12,7 +12,7 @@ NEW_DATASTORE_REQUEST = NewDatastoreRequest(
 NEW_DATASTORE = NewDatastore(
     rdn="no.new.testdatastore",
     description="new testdatastore",
-    directory="tests/resources/datastores/no-new-testdatastore",
+    directory="tests/resources/datastores/no.new.testdatastore",
     name="NEW TESTDATASTORE",
     bump_enabled=False,
 )


### PR DESCRIPTION
Ref issue https://github.com/orgs/statisticsnorway/projects/36/views/3?pane=issue&itemId=154689232&issue=statisticsnorway%7Cmicrodata-datastore-api%7C73

(I think the names of the datastore-directories in the tests etc also should be cleaned up, but that goes for all our repos. I have added it as a comment in the Cleanup after multitenancy task)
