### PR TITLE
actions: update actions/github-script to use newer Node

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - name: Call workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           INTEGRATION_TEST_REPO: ${{ secrets.INTEGRATION_TEST_REPO }}
           INTEGRATION_TEST_WORKFLOW: "${{ secrets.INTEGRATION_TEST_WORKFLOW }}.yaml"
@@ -137,7 +137,7 @@ jobs:
 
     steps:
       - name: Call workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           DEPLOY_REPO: ${{ secrets.DEPLOY_REPO }}
           DEPLOY_WORKFLOW: "${{ secrets.DEPLOY_WORKFLOW }}.yaml"


### PR DESCRIPTION
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/github-script@v7