### PR TITLE
Disambiguate the uv cache per workflow

### DIFF
--- a/.github/workflows/publish_public_image.yaml
+++ b/.github/workflows/publish_public_image.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          cache-suffix: publish
 
       - name: Sync dependencies
         run: uv sync

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions: {}
 

--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -34,6 +34,8 @@ jobs:
 
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        cache-suffix: build
     
     - name: Sync dependencies
       run: uv sync


### PR DESCRIPTION
Added a cache-suffix to each setup-uv step so the keys no longer collide.