### PR TITLE
Improve auth testing

### DIFF
--- a/datastore_api/adapter/auth/__init__.py
+++ b/datastore_api/adapter/auth/__init__.py
@@ -113,7 +113,7 @@ def _validate_rdn_in_aud(rdn: str, decoded_jwt: dict[str, Any]) -> None:
     if not aud:
         raise AuthError("Missing audience")
     aud_list = [aud] if isinstance(aud, str) else aud
-    if not any(rdn.startswith(a) for a in aud_list):
+    if not any(rdn == a or rdn.startswith(f"{a}.") for a in aud_list):
         raise AuthError(f"Not authorized to access datastore: {rdn}")
 
 

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -23,7 +23,6 @@ jwt_payload_no_accreditation_role = {
     "sub": "testuser",
 }
 
-# TODO: Add more payloads for testing
 
 PERSON_INCOME_ALL = (
     ";unit_id;value\n"

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -17,6 +17,12 @@ valid_jwt_payload = {
     "user/uuid": "12345",
 }
 
+jwt_payload_no_accreditation_role = {
+    "aud": ["no.ssb.fdb", "datastore-api-jobs"],
+    "exp": (datetime.now() + timedelta(hours=1)).timestamp(),
+    "sub": "testuser",
+}
+
 # TODO: Add more payloads for testing
 
 PERSON_INCOME_ALL = (

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -21,6 +21,7 @@ jwt_payload_no_accreditation_role = {
     "aud": ["no.ssb.fdb", "datastore-api-jobs"],
     "exp": (datetime.now() + timedelta(hours=1)).timestamp(),
     "sub": "testuser",
+    "user/uuid": "12345",
 }
 
 

--- a/tests/unit/adapter/auth/test_auth.py
+++ b/tests/unit/adapter/auth/test_auth.py
@@ -1,13 +1,11 @@
 from datetime import datetime, timedelta
 
 import pytest
-from fastapi.testclient import TestClient
 
 from datastore_api.adapter.auth import (
     AuthClient,
     MicrodataAuthClient,
     _decode_jwt,
-    get_auth_client,
 )
 from datastore_api.adapter.auth.dependencies import (
     ACCREDITATION_TOKEN_POLICY,
@@ -15,7 +13,6 @@ from datastore_api.adapter.auth.dependencies import (
     valid_aud_jobs,
 )
 from datastore_api.common.exceptions import AuthError
-from datastore_api.main import app
 from tests.resources import test_resources
 from tests.utils.util import encode_jwt_payload, generate_rsa_key_pairs
 
@@ -29,16 +26,6 @@ def auth_client() -> AuthClient:
         "utf-8"
     )  # type: ignore
     return auth_client
-
-
-@pytest.fixture
-def client(auth_client):
-    app.dependency_overrides[get_auth_client] = lambda: auth_client
-    yield TestClient(app)
-    app.dependency_overrides.clear()
-
-
-decode_policy = (ACCREDITATION_TOKEN_POLICY,)
 
 
 def test_auth_valid_token(auth_client):

--- a/tests/unit/adapter/auth/test_auth.py
+++ b/tests/unit/adapter/auth/test_auth.py
@@ -193,6 +193,22 @@ def test_auth_expired_token(auth_client):
     assert "Invalid token: Signature has expired" in str(e)
 
 
+def test_auth_invalid_signature(auth_client):
+    second_private_key, _ = generate_rsa_key_pairs()
+    token = encode_jwt_payload(
+        test_resources.valid_jwt_payload, second_private_key
+    )
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="no.ssb.fdb",
+        )
+    assert "Invalid token: Signature verification failed" in str(e)
+
+
 def test_auth_missing_token(auth_client):
     with pytest.raises(AuthError) as e:
         auth_client.authorize_jwt(

--- a/tests/unit/adapter/auth/test_auth.py
+++ b/tests/unit/adapter/auth/test_auth.py
@@ -117,7 +117,7 @@ def test_auth_no_audience(auth_client):
             authorization_token=token,
             rdn="no.ssb.fdb",
         )
-    assert "Invalid token" in str(e)
+    assert 'Invalid token: Token is missing the "aud" claim' in str(e)
 
 
 def test_auth_no_accreditation_role(auth_client):
@@ -132,7 +132,10 @@ def test_auth_no_accreditation_role(auth_client):
             authorization_token=token,
             rdn="no.ssb.fdb",
         )
-    assert "Invalid token" in str(e)
+    assert (
+        'Invalid token: Token is missing the "accreditation/role" claim'
+        in str(e)
+    )
 
 
 def test_auth_wrong_role(auth_client):
@@ -183,7 +186,7 @@ def test_auth_expired_token(auth_client):
             authorization_token=token,
             rdn="no.ssb.fdb",
         )
-    assert "Invalid token" in str(e)
+    assert "Invalid token: Signature has expired" in str(e)
 
 
 def test_auth_missing_token(auth_client):

--- a/tests/unit/adapter/auth/test_auth.py
+++ b/tests/unit/adapter/auth/test_auth.py
@@ -56,6 +56,23 @@ def test_auth_valid_token_root_aud(auth_client):
     )
 
 
+def test_auth_root_aud_does_not_match_unrelated_rdn(auth_client):
+    payload = {
+        **test_resources.valid_jwt_payload,
+        "aud": ["no", "datastore-api-jobs"],
+    }
+    token = encode_jwt_payload(payload, JWT_PRIVATE_KEY)
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="nope.evil.datastore",
+        )
+    assert "Not authorized to access datastore: nope.evil.datastore" in str(e)
+
+
 def test_auth_no_datastore_in_aud(auth_client):
     payload = {
         **test_resources.valid_jwt_payload,

--- a/tests/unit/adapter/auth/test_auth.py
+++ b/tests/unit/adapter/auth/test_auth.py
@@ -1,26 +1,200 @@
+from datetime import datetime, timedelta
+
 import pytest
+from fastapi.testclient import TestClient
 
 from datastore_api.adapter.auth import (
-    TokenPolicy,
+    AuthClient,
+    MicrodataAuthClient,
     _decode_jwt,
+    get_auth_client,
+)
+from datastore_api.adapter.auth.dependencies import (
+    ACCREDITATION_TOKEN_POLICY,
+    DATA_ADMINISTRATOR_ROLE,
+    valid_aud_jobs,
 )
 from datastore_api.common.exceptions import AuthError
+from datastore_api.main import app
 from tests.resources import test_resources
 from tests.utils.util import encode_jwt_payload, generate_rsa_key_pairs
 
 JWT_PRIVATE_KEY, JWT_PUBLIC_KEY = generate_rsa_key_pairs()
 
 
-ACCREDITATION_TOKEN_POLICY = TokenPolicy(
-    user_id_claim="user/uuid",
-    required_claims=[
-        "aud",
-        "sub",
-        "accreditation/role",
-        "user/uuid",
-    ],
-)
+@pytest.fixture
+def auth_client() -> AuthClient:
+    auth_client = MicrodataAuthClient()
+    auth_client._get_signing_key = lambda jwt_token: JWT_PUBLIC_KEY.decode(
+        "utf-8"
+    )  # type: ignore
+    return auth_client
+
+
+@pytest.fixture
+def client(auth_client):
+    app.dependency_overrides[get_auth_client] = lambda: auth_client
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
 decode_policy = (ACCREDITATION_TOKEN_POLICY,)
+
+
+def test_auth_valid_token(auth_client):
+    token = encode_jwt_payload(
+        test_resources.valid_jwt_payload, JWT_PRIVATE_KEY
+    )
+    auth_client.authorize_jwt(
+        required_aud=valid_aud_jobs,
+        decode_policy=ACCREDITATION_TOKEN_POLICY,
+        required_role=DATA_ADMINISTRATOR_ROLE,
+        authorization_token=token,
+        rdn="no.ssb.fdb",
+    )
+
+
+def test_auth_valid_token_root_aud(auth_client):
+    payload = {
+        **test_resources.valid_jwt_payload,
+        "aud": ["no", "datastore-api-jobs"],
+    }
+    token = encode_jwt_payload(payload, JWT_PRIVATE_KEY)
+    auth_client.authorize_jwt(
+        required_aud=valid_aud_jobs,
+        decode_policy=ACCREDITATION_TOKEN_POLICY,
+        required_role=DATA_ADMINISTRATOR_ROLE,
+        authorization_token=token,
+        rdn="no.testdatastore",
+    )
+
+
+def test_auth_no_datastore_in_aud(auth_client):
+    payload = {
+        **test_resources.valid_jwt_payload,
+        "aud": ["datastore-api-jobs"],
+    }
+    token = encode_jwt_payload(payload, JWT_PRIVATE_KEY)
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="no.ssb.fdb",
+        )
+    assert "Not authorized to access datastore: no.ssb.fdb" in str(e)
+
+
+def test_auth_datastore_not_in_audience(auth_client):
+    payload = {
+        **test_resources.valid_jwt_payload,
+        "aud": ["no.ssb.fdb", "datastore-api-jobs"],
+    }
+    token = encode_jwt_payload(payload, JWT_PRIVATE_KEY)
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="no.provider1.test",
+        )
+    assert "Not authorized to access datastore: no.provider1.test" in str(e)
+
+
+def test_auth_no_audience(auth_client):
+    payload = {
+        **test_resources.valid_jwt_payload,
+        "aud": [],
+    }
+    token = encode_jwt_payload(payload, JWT_PRIVATE_KEY)
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="no.ssb.fdb",
+        )
+    assert "Invalid token" in str(e)
+
+
+def test_auth_no_accreditation_role(auth_client):
+    token = encode_jwt_payload(
+        test_resources.jwt_payload_no_accreditation_role, JWT_PRIVATE_KEY
+    )
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="no.ssb.fdb",
+        )
+    assert "Invalid token" in str(e)
+
+
+def test_auth_wrong_role(auth_client):
+    payload = {
+        **test_resources.valid_jwt_payload,
+        "accreditation/role": "role/invalidrole",
+    }
+    token = encode_jwt_payload(payload, JWT_PRIVATE_KEY)
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="no.ssb.fdb",
+        )
+    assert "Unauthorized with role: role/invalidrole" in str(e)
+
+
+def test_auth_wrong_audience(auth_client):
+    payload = {
+        **test_resources.valid_jwt_payload,
+        "aud": ["wrong-audience"],
+    }
+    token = encode_jwt_payload(payload, JWT_PRIVATE_KEY)
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="no.ssb.fdb",
+        )
+    assert "Invalid token: Audience doesn't match" in str(e)
+
+
+def test_auth_expired_token(auth_client):
+    payload = {
+        **test_resources.valid_jwt_payload,
+        "exp": (datetime.now() - timedelta(hours=1)).timestamp(),
+    }
+    token = encode_jwt_payload(payload, JWT_PRIVATE_KEY)
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=token,
+            rdn="no.ssb.fdb",
+        )
+    assert "Invalid token" in str(e)
+
+
+def test_auth_missing_token(auth_client):
+    with pytest.raises(AuthError) as e:
+        auth_client.authorize_jwt(
+            required_aud=valid_aud_jobs,
+            decode_policy=ACCREDITATION_TOKEN_POLICY,
+            required_role=DATA_ADMINISTRATOR_ROLE,
+            authorization_token=None,
+        )
+    assert "Unauthorized. No token was provided" in str(e)
 
 
 def test_decoding_signing_key():

--- a/tests/unit/api/data/test_data_routes.py
+++ b/tests/unit/api/data/test_data_routes.py
@@ -35,16 +35,23 @@ def mock_db_client():
 
 
 @pytest.fixture
-def client(mock_db_client: Mock):
+def mock_auth_deps():
+    return {
+        "user": Mock(return_value=None),
+    }
+
+
+@pytest.fixture
+def client(mock_db_client: Mock, mock_auth_deps: dict):
     app.dependency_overrides[db.get_database_client] = lambda: mock_db_client
-    app.dependency_overrides[authorize_user] = lambda: None
+    app.dependency_overrides[authorize_user] = lambda: mock_auth_deps["user"]()
     app.dependency_overrides[generate_data_filter] = lambda: None
     app.dependency_overrides[get_data_reader] = FakeDataReader
     yield TestClient(app)
     app.dependency_overrides.clear()
 
 
-def test_data_event_stream_result(client: TestClient):
+def test_data_event_stream_result(client: TestClient, mock_auth_deps: dict):
     response = client.post(
         "/datastores/no.ssb.test/data/event/stream",
         json={
@@ -55,13 +62,13 @@ def test_data_event_stream_result(client: TestClient):
         },
         headers={"Authorization": "Bearer valid-token"},
     )
-
+    mock_auth_deps["user"].assert_called_once()
     reader = pa.BufferReader(response.content)
     assert response.status_code == 200
     assert pq.read_table(reader) == MOCK_RESULT
 
 
-def test_data_status_stream_result(client: TestClient):
+def test_data_status_stream_result(client: TestClient, mock_auth_deps: dict):
     response = client.post(
         "/datastores/no.ssb.test/data/status/stream",
         json={
@@ -71,19 +78,19 @@ def test_data_status_stream_result(client: TestClient):
         },
         headers={"Authorization": "Bearer valid-token"},
     )
-
+    mock_auth_deps["user"].assert_called_once()
     reader = pa.BufferReader(response.content)
     assert response.status_code == 200
     assert pq.read_table(reader) == MOCK_RESULT
 
 
-def test_data_fixed_stream_result(client: TestClient):
+def test_data_fixed_stream_result(client: TestClient, mock_auth_deps: dict):
     response = client.post(
         "/datastores/no.ssb.test/data/fixed/stream",
         json={"version": "1.0.0.0", "dataStructureName": "FAKE_NAME"},
         headers={"Authorization": "Bearer valid-token"},
     )
-
+    mock_auth_deps["user"].assert_called_once()
     reader = pa.BufferReader(response.content)
     assert response.status_code == 200
     assert pq.read_table(reader) == MOCK_RESULT

--- a/tests/unit/api/test_datastores.py
+++ b/tests/unit/api/test_datastores.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from datastore_api.adapter import db
 from datastore_api.adapter.auth.dependencies import (
+    authorize_api_key,
     authorize_datastore_provisioner,
 )
 from datastore_api.adapter.db.models import Datastore, UserInfo
@@ -47,6 +48,7 @@ def mock_db_client():
 def mock_auth_deps():
     return {
         "datastore_provisioner": Mock(return_value=USER_INFO),
+        "api_key": Mock(return_value=None),
     }
 
 
@@ -57,6 +59,9 @@ def client(mock_db_client, mock_auth_deps):
     app.dependency_overrides[authorize_datastore_provisioner] = lambda: (
         mock_auth_deps["datastore_provisioner"]()
     )
+    app.dependency_overrides[authorize_api_key] = lambda: mock_auth_deps[
+        "api_key"
+    ]()
     yield TestClient(app, raise_server_exceptions=False)
     app.dependency_overrides.clear()
 
@@ -65,12 +70,14 @@ def test_get_datastore(client, mock_auth_deps):
     response = client.get(
         "/datastores/no.dev.test", headers={"X-Request-ID": "abc123"}
     )
+    mock_auth_deps["datastore_provisioner"].assert_called_once()
     assert response.status_code == 200
     assert response.json() == DATASTORE.model_dump()
 
 
-def test_get_datastores(client):
+def test_get_datastores(client, mock_auth_deps):
     response = client.get("/datastores", headers={"X-Request-ID": "abc123"})
+    mock_auth_deps["datastore_provisioner"].assert_called_once()
     assert response.status_code == 200
     assert response.json() == [DATASTORE.model_dump()]
 
@@ -108,11 +115,12 @@ def test_get_datastores_rdns(client):
     assert response.json() == ["no.dev.test"]
 
 
-def test_get_datastore_directory(client):
+def test_get_datastore_directory(client, mock_auth_deps):
     response = client.get(
         "/datastores/no.dev.test/directory",
         headers={"X-Request-ID": "abc123"},
     )
+    mock_auth_deps["api_key"].assert_called_once()
     assert response.status_code == 200
     assert response.json() == DATASTORE.directory
 

--- a/tests/unit/api/test_maintenance_statuses.py
+++ b/tests/unit/api/test_maintenance_statuses.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from datastore_api.adapter import db
+from datastore_api.adapter.auth.dependencies import authorize_api_key
 from datastore_api.main import app
 
 MAINTENANCE_STATUS_REQUEST_VALID = {"msg": "we upgrade chill", "paused": True}
@@ -48,17 +49,28 @@ def mock_db_client():
 
 
 @pytest.fixture
-def client(mock_db_client):
+def mock_auth_deps():
+    return {
+        "api_key": Mock(return_value=None),
+    }
+
+
+@pytest.fixture
+def client(mock_db_client, mock_auth_deps):
     app.dependency_overrides[db.get_database_client] = lambda: mock_db_client
+    app.dependency_overrides[authorize_api_key] = lambda: mock_auth_deps[
+        "api_key"
+    ]()
     yield TestClient(app)
     app.dependency_overrides.clear()
 
 
-def test_set_maintenance_status(client, mock_db_client):
+def test_set_maintenance_status(client, mock_db_client, mock_auth_deps):
     response = client.post(
         "/maintenance-statuses",
         json=MAINTENANCE_STATUS_REQUEST_VALID,
     )
+    mock_auth_deps["api_key"].assert_called_once()
     mock_db_client.set_maintenance_status.assert_called_once()
     assert response.status_code == 200
     assert response.json() == NEW_STATUS

--- a/tests/unit/api/test_public_vault.py
+++ b/tests/unit/api/test_public_vault.py
@@ -64,7 +64,7 @@ def client(mock_auth_deps: dict, mock_db_client: Mock):
 
 
 def test_save_public_key(client: TestClient, mock_auth_deps: dict):
-    client.post(
+    response = client.post(
         "/datastores/no.ssb.test/public-key",
         content=PUBLIC_KEY_BYTES,
         headers={"Content-Type": "application/x-pem-file", "X-API-Key": "abc"},

--- a/tests/unit/api/test_public_vault.py
+++ b/tests/unit/api/test_public_vault.py
@@ -69,6 +69,7 @@ def test_save_public_key(client: TestClient, mock_auth_deps: dict):
         content=PUBLIC_KEY_BYTES,
         headers={"Content-Type": "application/x-pem-file", "X-API-Key": "abc"},
     )
+    assert response.status_code == 200
     mock_auth_deps["api_key"].assert_called_once()
     assert PUBLIC_KEY_PATH.is_file()
 

--- a/tests/unit/api/test_public_vault.py
+++ b/tests/unit/api/test_public_vault.py
@@ -10,7 +10,11 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi.testclient import TestClient
 from httpx import Response
 
-from datastore_api.adapter import auth, db
+from datastore_api.adapter import db
+from datastore_api.adapter.auth.dependencies import (
+    authorize_api_key,
+    authorize_data_administrator,
+)
 from datastore_api.api.datastores.public_key import PUBLIC_KEY_FILE_NAME
 from datastore_api.main import app
 
@@ -36,10 +40,11 @@ PUBLIC_KEY_PATH = Path(
 
 
 @pytest.fixture
-def mock_auth_client():
-    mock = Mock()
-    mock.check_api_key.return_value = None
-    return mock
+def mock_auth_deps():
+    return {
+        "api_key": Mock(return_value=None),
+        "data_administrator": Mock(return_value=None),
+    }
 
 
 @pytest.fixture
@@ -53,8 +58,13 @@ def mock_db_client():
 
 
 @pytest.fixture
-def client(mock_auth_client: Mock, mock_db_client: Mock):
-    app.dependency_overrides[auth.get_auth_client] = lambda: mock_auth_client
+def client(mock_auth_deps: dict, mock_db_client: Mock):
+    app.dependency_overrides[authorize_api_key] = lambda: mock_auth_deps[
+        "api_key"
+    ]()
+    app.dependency_overrides[authorize_data_administrator] = lambda: (
+        mock_auth_deps["data_administrator"]()
+    )
     app.dependency_overrides[db.get_database_client] = lambda: mock_db_client
     yield TestClient(app)
     app.dependency_overrides.clear()
@@ -62,12 +72,13 @@ def client(mock_auth_client: Mock, mock_db_client: Mock):
         os.remove(PUBLIC_KEY_PATH)
 
 
-def test_save_public_key(client: TestClient):
+def test_save_public_key(client: TestClient, mock_auth_deps: dict):
     client.post(
         "/datastores/no.ssb.test/public-key",
         content=PUBLIC_KEY_BYTES,
         headers={"Content-Type": "application/x-pem-file", "X-API-Key": "abc"},
     )
+    mock_auth_deps["api_key"].assert_called_once()
     assert PUBLIC_KEY_PATH.is_file()
 
 
@@ -91,13 +102,14 @@ def test_create_key_empty_bytes(client: TestClient):
     assert response.status_code == 400
 
 
-def test_get_public_key(client: TestClient):
+def test_get_public_key(client: TestClient, mock_auth_deps: dict):
     PUBLIC_KEY_PATH.write_bytes(PUBLIC_KEY_BYTES)
 
     response: Response = client.get(
         "/datastores/no.ssb.test/public-key",
         headers={"Content-Type": "application/x-pem-file"},
     )
+    mock_auth_deps["data_administrator"].assert_called_once()
     assert response.status_code == 200
     assert response.content == PUBLIC_KEY_BYTES
 


### PR DESCRIPTION
This PR improves auth test coverage with JWT validation and missing endpoint auth assertions.
(Same JWT validation testing as in datastore-admin)

Ref Issue #74 